### PR TITLE
Enhancements: enable "translate" command, add command-line options

### DIFF
--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -17,5 +17,7 @@ dependencies:
     - README.md
     - transcribe.py
     - configure.sh
+    - translate.py
 commands:
   transcribe : Convert an audio file into text.
+  translate  : Translate audio from a file into English text.

--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -20,4 +20,4 @@ dependencies:
     - translate.py
 commands:
   transcribe : Convert an audio file into text.
-  translate  : Translate audio from a file into English text.
+  translate : Translate audio from a file into English text.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ to see
 
 ## Options
 
-* `-l`, `--lang`: Specify the language of the source audio to speed up the transcribe/translate process.  
-For example, to transcribe audio in English, use `-l en`.  
+* `-l`, `--lang`: Specify the language of the source audio.  
+This will speed up the transcribe/translate process.  
 See [tokenizer.py](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py) for the list of all available languages.
 
 * `-o`, `--output`: Specify the output file name and format.  

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ speech from an audio file.
 * Command line tools
   ```bash
   ml transcribe openai myspeech.wav
+  ml translate openai myspeech.wav
   ```
 
 * Quick test
@@ -41,3 +42,23 @@ to see
   Tacos al pastor are my favorite. 
   A zestful food is the hot cross bun.
   ```
+
+## Options
+
+* `-l`, `--lang`: Specify the language of the source audio to speed up the transcribe/translate process.  
+For example, to transcribe audio in English, use `-l en`.  
+See [tokenizer.py](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py) for the list of all available languages.
+
+* `-o`, `--output`: Specify the output file name and format.  
+For example, `-o output.txt` will save the transcribed text to a file named `output.txt` in the same directory.
+
+Format:  
+`ml transcribe openai [FILENAME] [-l LANGUAGE] [-o OUTPUT_FILE]`  
+`ml translate openai [FILENAME] [-l LANGUAGE] [-o OUTPUT_FILE]`
+
+Examples:
+```bash
+ml transcribe openai myspeech.wav -l en -o output.txt
+ml translate openai myspeech.wav -l en -o output.txt
+```
+

--- a/transcribe.py
+++ b/transcribe.py
@@ -82,8 +82,9 @@ specify the desired output file name and format (e.g. `output.txt`).
         output_path = os.path.join(get_cmd_cwd(), output)
         with open(output_path, "w") as f:
             f.write(text)
-    
-    print(text)
+        print("Transcribed text saved to", output_path)
+    else:
+        print(text)
 
 if __name__ == "__main__":
     cli(prog_name="transcribe")

--- a/transcribe.py
+++ b/transcribe.py
@@ -40,7 +40,7 @@ def cli(filename, lang):
 
 Tested with wav, mp4.
 
-The audio is processed locally using a downlaoded OpenAI model The
+The audio is processed locally using a downloaded OpenAI model The
 result is returned as text.
 
     """
@@ -65,7 +65,8 @@ result is returned as text.
     if not os.path.exists(path):
         sys.exit(f"{pkg} {cmd}: File not found: {path}")
         
-    result = model.transcribe(path, fp16=False) # fp16 not supported on CPU
+    # fp16 not supported on CPU
+    result = model.transcribe(path, fp16=False, language=lang)
 
     print(result["text"].strip())
 

--- a/transcribe.py
+++ b/transcribe.py
@@ -79,7 +79,7 @@ specify the desired output file name and format (e.g. `output.txt`).
     text = result["text"].strip()
 
     if output:
-        output_path = os.path.join(os.getcwd(), output)
+        output_path = os.path.join(get_cmd_cwd(), output)
         with open(output_path, "w") as f:
             f.write(text)
     

--- a/transcribe.py
+++ b/transcribe.py
@@ -66,7 +66,7 @@ result is returned as text.
         sys.exit(f"{pkg} {cmd}: File not found: {path}")
         
     # fp16 not supported on CPU
-    result = model.transcribe(path, fp16=False, language=lang)
+    result = model.transcribe(path, fp16=False, language=lang, verbose=True)
 
     print(result["text"].strip())
 

--- a/transcribe.py
+++ b/transcribe.py
@@ -34,8 +34,12 @@ from mlhub.pkg import get_cmd_cwd
               default=None,
               type=click.STRING,
               help="The language of the source audio.")
+@click.option("-o", "--output",
+              default=None,
+              type=click.STRING,
+              help="Output file name and format. e.g. output.txt, output.json")
 
-def cli(filename, lang):
+def cli(filename, lang, output):
     """Transcribe audio from a file.
 
 Tested with wav, mp4.
@@ -66,9 +70,14 @@ result is returned as text.
         sys.exit(f"{pkg} {cmd}: File not found: {path}")
         
     # fp16 not supported on CPU
-    result = model.transcribe(path, fp16=False, language=lang, verbose=True)
+    result = model.transcribe(path, fp16=False, language=lang)
+    text = result["text"].strip()
 
-    print(result["text"].strip())
+    if output:
+        with open(output, "w") as f:
+            f.write(text)
+    else:
+        print(text)
 
 if __name__ == "__main__":
     cli(prog_name="transcribe")

--- a/transcribe.py
+++ b/transcribe.py
@@ -42,10 +42,15 @@ from mlhub.pkg import get_cmd_cwd
 def cli(filename, lang, output):
     """Transcribe audio from a file.
 
-Tested with wav, mp4.
+Tested with wav, mp4, mov.
 
 The audio is processed locally using a downloaded OpenAI model The
 result is returned as text.
+
+Use the `-l` or `--lang` option to specify the language of the source audio.
+
+To save the transcribed text to a file, use the `-o` or `--output` option to 
+specify the desired output file name and format (e.g. `output.txt`).
 
     """
     pkg = "openai"
@@ -74,10 +79,11 @@ result is returned as text.
     text = result["text"].strip()
 
     if output:
-        with open(output, "w") as f:
+        output_path = os.path.join(os.getcwd(), output)
+        with open(output_path, "w") as f:
             f.write(text)
-    else:
-        print(text)
+    
+    print(text)
 
 if __name__ == "__main__":
     cli(prog_name="transcribe")

--- a/translate.py
+++ b/translate.py
@@ -79,7 +79,7 @@ specify the desired output file name and format (e.g. `output.txt`).
     text = result["text"].strip()
 
     if output:
-        output_path = os.path.join(os.getcwd(), output)
+        output_path = os.path.join(get_cmd_cwd(), output)
         with open(output_path, "w") as f:
             f.write(text)
     

--- a/translate.py
+++ b/translate.py
@@ -66,7 +66,7 @@ result is returned as text.
     if not os.path.exists(path):
         sys.exit(f"{pkg} {cmd}: File not found: {path}")
         
-    result = model.transcribe(path, fp16=False, task="translate", language=lang)
+    result = model.transcribe(path, fp16=False, task="translate", language=lang, verbose=True)
 
     print(result["text"])
     

--- a/translate.py
+++ b/translate.py
@@ -42,10 +42,15 @@ from mlhub.pkg import get_cmd_cwd
 def cli(filename, lang, output):
     """Translate audio from a file into English.
 
-Tested with wav, mp4.
+Tested with wav, mp4, mov.
 
 The audio is processed locally using a downloaded OpenAI model. The
 result is returned as text.
+
+Use the `-l` or `--lang` option to specify the language of the source audio.
+
+To save the translated text to a file, use the `-o` or `--output` option to 
+specify the desired output file name and format (e.g. `output.txt`).
 
     """
 
@@ -74,10 +79,11 @@ result is returned as text.
     text = result["text"].strip()
 
     if output:
-        with open(output, "w") as f:
+        output_path = os.path.join(os.getcwd(), output)
+        with open(output_path, "w") as f:
             f.write(text)
-    else:
-        print(text)
+    
+    print(text)
     
 if __name__ == "__main__":
     cli(prog_name="translate")

--- a/translate.py
+++ b/translate.py
@@ -40,7 +40,7 @@ def cli(filename, lang):
 
 Tested with wav, mp4.
 
-The audio is processed locally using a downlaoded OpenAI model. The
+The audio is processed locally using a downloaded OpenAI model. The
 result is returned as text.
 
     """
@@ -66,7 +66,7 @@ result is returned as text.
     if not os.path.exists(path):
         sys.exit(f"{pkg} {cmd}: File not found: {path}")
         
-    result = model.transcribe(path, fp16=False, task="translate")
+    result = model.transcribe(path, fp16=False, task="translate", language=lang)
 
     print(result["text"])
     

--- a/translate.py
+++ b/translate.py
@@ -34,8 +34,12 @@ from mlhub.pkg import get_cmd_cwd
               default=None,
               type=click.STRING,
               help="The language of the source audio (auto).")
+@click.option("-o", "--output",
+              default=None,
+              type=click.STRING,
+              help="Output file name and format. e.g. output.txt, output.json")
 
-def cli(filename, lang):
+def cli(filename, lang, output):
     """Translate audio from a file into English.
 
 Tested with wav, mp4.
@@ -66,9 +70,14 @@ result is returned as text.
     if not os.path.exists(path):
         sys.exit(f"{pkg} {cmd}: File not found: {path}")
         
-    result = model.transcribe(path, fp16=False, task="translate", language=lang, verbose=True)
+    result = model.transcribe(path, fp16=False, task="translate", language=lang)
+    text = result["text"].strip()
 
-    print(result["text"])
+    if output:
+        with open(output, "w") as f:
+            f.write(text)
+    else:
+        print(text)
     
 if __name__ == "__main__":
     cli(prog_name="translate")

--- a/translate.py
+++ b/translate.py
@@ -82,8 +82,9 @@ specify the desired output file name and format (e.g. `output.txt`).
         output_path = os.path.join(get_cmd_cwd(), output)
         with open(output_path, "w") as f:
             f.write(text)
-    
-    print(text)
+        print("Translated text saved to", output_path)
+    else:
+        print(text)
     
 if __name__ == "__main__":
     cli(prog_name="translate")


### PR DESCRIPTION

Enhancement of the functionalities of MLHub's OpenAI tool.

Changes include:
- Fix the "translate" command and make "translate" work as expected.
- Add a command-line option to specify the language of the input audio file.
- Add a command-line option to save the output text into a file of different types.
- Update the README file.